### PR TITLE
7 not recalculating true anomaly for post compiled phase curves

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,10 @@
+Changelog
+++++++++++
+
+**0.1.2 (05/2024)**
+
+Fixed issue #7. Previously, calls to ``OblateSystem.lightcurve()`` after initializing the ``OblateSystem`` object were not recalculating true anomalies even if the ``period`` and/or ``t_peri`` changed.
+
+**0.1.1 (05/2024)**
+
+Initial JOSS submission version, fixed issues #1 and #5.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ installation
 quickstart
 geometry
 contributing
+changelog
 ```
 
 ```{toctree}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "squishyplanet"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.9"
 dependencies = [
     "requests",

--- a/tests/test_oblate_system.py
+++ b/tests/test_oblate_system.py
@@ -208,6 +208,9 @@ def test_lightcurve():
     state["compute_stellar_ellipsoidal_variations"] = True
     state["compute_stellar_doppler_variations"] = True
 
+    planet = OblateSystem(**state)
+    _ = planet.lightcurve()
+
     # for key, value in state.items():
     #     if (type(value) != int) & (type(value) != bool):
     #         if key in ["times", "data", "uncertainties", "exoposure_time"]:


### PR DESCRIPTION
Fixes #7, forces recalculation of true anomalies prior to any phase curve calculations in `OblateSystem.lightcurve()`.